### PR TITLE
Fix AttributeError thrown during FFRuntimeError initialization

### DIFF
--- a/ffmpy3.py
+++ b/ffmpy3.py
@@ -267,9 +267,9 @@ class FFRuntimeError(Exception):
 
         message = "`{0}` exited with status {1}\n\nSTDOUT:\n{2}\n\nSTDERR:\n{3}".format(
             self.cmd,
-            exit_code,
-            stdout.decode(),
-            stderr.decode()
+            self.exit_code,
+            self.stdout.decode(),
+            self.stderr.decode()
         )
 
         super(FFRuntimeError, self).__init__(message)

--- a/ffmpy3.py
+++ b/ffmpy3.py
@@ -259,11 +259,11 @@ class FFRuntimeError(Exception):
         The contents of stderr (only if executed synchronously).
     """
 
-    def __init__(self, cmd, exit_code, stdout=b'', stderr=b''):
+    def __init__(self, cmd, exit_code, stdout, stderr):
         self.cmd = cmd
         self.exit_code = exit_code
-        self.stdout = stdout
-        self.stderr = stderr
+        self.stdout = stdout or b''
+        self.stderr = stderr or b''
 
         message = "`{0}` exited with status {1}\n\nSTDOUT:\n{2}\n\nSTDERR:\n{3}".format(
             self.cmd,


### PR DESCRIPTION
I wanted to convert the h265 stream into mp4 video and got an error from ffmpeg, but the issue is that the `stdout` and `stderr` were None, which caused the `ffmpy3.FFRuntimeError` to crash during initialization.

```
Could not write header for output file #0 (incorrect codec parameters ?): Invalid argument
Stream mapping:
  Stream #0:0 -> #0:0 (copy)
    Last message repeated 1 times
Traceback (most recent call last):
  File "/home/vandavv/dev/luxonis/depthai/depthai_demo.py", line 813, in <module>
    enc_manager.close()
  File "/home/vandavv/dev/luxonis/depthai/depthai_demo.py", line 671, in close
    ff.run()
  File "/home/vandavv/dev/luxonis/venvs/demo/lib/python3.8/site-packages/ffmpy3.py", line 130, in run
    raise FFRuntimeError(self.cmd, self.process.returncode, out[0], out[1])
  File "/home/vandavv/dev/luxonis/venvs/demo/lib/python3.8/site-packages/ffmpy3.py", line 273, in __init__
    stdout.decode(),
AttributeError: 'NoneType' object has no attribute 'decode'
```

This PR fixes this issue and now it's being thrown correctly
```
Could not write header for output file #0 (incorrect codec parameters ?): Invalid argument
Stream mapping:
  Stream #0:0 -> #0:0 (copy)
    Last message repeated 1 times
Traceback (most recent call last):
  File "/home/vandavv/dev/luxonis/depthai/depthai_demo.py", line 671, in close
    ff.run()
  File "/home/vandavv/dev/luxonis/venvs/demo/lib/python3.8/site-packages/ffmpy3.py", line 130, in run
    raise FFRuntimeError(self.cmd, self.process.returncode, out[0], out[1])
ffmpy3.FFRuntimeError: `ffmpeg -y -i /home/vandavv/dev/luxonis/depthai/color.h265 -c copy -framerate 30.0 /home/vandavv/dev/luxonis/depthai/color.mp4` exited with status 1

STDOUT:


STDERR:

```