### PR TITLE
Making stdout and stderr optional again

### DIFF
--- a/ffmpy3.py
+++ b/ffmpy3.py
@@ -259,7 +259,7 @@ class FFRuntimeError(Exception):
         The contents of stderr (only if executed synchronously).
     """
 
-    def __init__(self, cmd, exit_code, stdout, stderr):
+    def __init__(self, cmd, exit_code, stdout=b'', stderr=b''):
         self.cmd = cmd
         self.exit_code = exit_code
         self.stdout = stdout or b''


### PR DESCRIPTION
Still has the `or b''` added in #5, but now doesn't raise an exception on Line 213 when creating error without stdout and stderr.

This should fix #6 